### PR TITLE
Abstract Pantheon authentication to Circle setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,19 @@ Need to improve this test runner in some way? You can clone the repository local
 
 **BY FORCE PUSHING AGAINST `PANTHEON_BRANCH` AND ERASING THE DATABASE, THIS TEST RUNNER IRREVOCABLY DAMAGES YOUR PANTHEON SITE. USE ONLY WITH A SINGLE-USE, "THROWAWAY" SITE. DO NOT USE WITH ANY PANTHEON SITE THAT CANNOT BE DELETED.** 
 
-With the warning out of the way and Terminus already installed on your machine, here's how you can use the test runner locally:
+With the warning out of the way, here's how you can use the test runner locally.
+
+First, make sure Terminus is installed and authenticated:
+
+    composer global require pantheon-systems/terminus
+    terminus auth login --machine-token=<secret-token>
+
+Then, you can clone and use the test runner:
 
     git clone git@github.com:pantheon-systems/pantheon-wordpress-develop.git
     cd pantheon-wordpress-develop
     export PANTHEON_SITE=<disposable-site>
     export PANTHEON_BRANCH=<disposable-branch>
-    export TERMINUS_TOKEN=<secret-token>
     ./prepare.sh
     ./test.sh
     ./cleanup.sh

--- a/circle.yml
+++ b/circle.yml
@@ -12,6 +12,7 @@ dependencies:
     - ~/.composer/cache
   override:
     - composer global require pantheon-systems/terminus
+    - terminus auth login --machine-token=$TERMINUS_TOKEN
 
 test:
   pre:

--- a/prepare.sh
+++ b/prepare.sh
@@ -1,12 +1,5 @@
 #!/bin/bash
 
-###
-# Authenticate with Terminus to perform site management operations.
-#
-# The $TERMINUS_TOKEN environment variable must be set with a valid machine token.
-###
-terminus auth login --machine-token=$TERMINUS_TOKEN
-
 set -ex
 
 ###


### PR DESCRIPTION
It doesn't make sense to have Terminus authenitication as a part of the
prepare step. Instead, let's assume the driver is already authenticated
by the time we get to `./prepare.sh`
