### PR TITLE
Changing php version for ubuntu 14.04

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,7 @@
 machine:
   php:
     # https://circleci.com/docs/environment#php
-    version: 5.5.11
+    version: 5.6.22
   environment:
     # DB config. Using default CircleCI's database.
     TERMINUS_ENV: ci-$CIRCLE_BUILD_NUM


### PR DESCRIPTION
Changes in Terminus authentication required switching CircleCI from Ubuntu 12.04 to 14.04. That change then requires updating PHP versions.
